### PR TITLE
Allow Antlers templates in Blade Layouts.

### DIFF
--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -9,7 +9,11 @@
     </head>
     <body class="bg-gray-100 font-sans leading-normal text-gray-800">
         <div class="mx-auto px-2 h-screen flex items-center justify-center">
-            @yield('content')
+            @if(! empty($template_content))
+                {!! $template_content !!}
+            @else
+                @yield('content')
+            @endisset
         </div>
         <script src="{{ mix('/js/site.js') }}"></script>
     </body>


### PR DESCRIPTION
Howdy, 

This just adds the template_content variable as an option, should there be a case where a Antlers template is being used with a Blade layout, see [documentation](https://statamic.dev/template-engines#layouts)